### PR TITLE
Add modRewrite to gruntfile livereload

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -89,6 +89,9 @@ module.exports = function (grunt) {
           open: true,
           middleware: function (connect) {
             return [
+              modRewrite([
+                '!\\.html|\\.js|\\.css|\\.png|\\.woff|\\.ttf|\\.eot|\\.gif|\\.jpg|\\.svg$ /index.html [L]'
+              ]),
               connect.static('.tmp'),
               connect().use(
                 '/bower_components',


### PR DESCRIPTION
Using HTML5 URL Rewriting causes issues with GET requests. This allows access to most if not all files necessary.

ref: http://stackoverflow.com/questions/16569841/angularjs-html5-mode-reloading-the-page-gives-wrong-get-request
